### PR TITLE
인근지역 레스토랑 조회 API 구현

### DIFF
--- a/src/main/java/com/wanted/lunchmapservice/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/controller/RestaurantController.java
@@ -4,8 +4,10 @@ import com.wanted.lunchmapservice.common.dto.CustomPage;
 import com.wanted.lunchmapservice.common.dto.ResponseDto;
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseGetRestaurantDetailDto;
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseGetRestaurantSimpleDto;
+import com.wanted.lunchmapservice.restaurant.controller.dto.RestaurantResponseDto;
 import com.wanted.lunchmapservice.restaurant.repository.dto.RequestRestaurantGetFilterDto;
 import com.wanted.lunchmapservice.restaurant.service.RestaurantGetService;
+import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -33,5 +35,10 @@ public class RestaurantController {
     return ResponseEntity.ok(getService.getRestaurant(request, pageable));
   }
 
+  @GetMapping("/nearby")
+  public ResponseEntity<ResponseDto<CustomPage<RestaurantResponseDto>>> getRecommendedRestaurant(@ModelAttribute
+  NearRestaurantRequestDto dto, Pageable pageable) {
+    return ResponseEntity.ok(getService.findNearbyRestaurant(dto,pageable));
+  }
 }
 

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/controller/dto/NearRestaurantRequestDto.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/controller/dto/NearRestaurantRequestDto.java
@@ -1,0 +1,21 @@
+package com.wanted.lunchmapservice.restaurant.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NearRestaurantRequestDto {
+
+  @NotNull(message = "추천받을 위치의 경도를 입력해 주세요.")
+  private String currentLongitude;
+  @NotNull(message = "추천받을 위치의 위도를 입력해 주세요.")
+  private String currentLatitude;
+  @NotNull(message = "현재 위치에서 조화하고 싶은 맛집의 반경을 입력해 주세요.")
+  private Double range;
+}

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/controller/dto/RestaurantResponseDto.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/controller/dto/RestaurantResponseDto.java
@@ -1,0 +1,20 @@
+package com.wanted.lunchmapservice.restaurant.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RestaurantResponseDto {
+
+  private Long id;
+  private Long locationId;
+  private String name;
+  private String lotNumberAddress;
+  private String roadNameAddress;
+  private String zipCode;
+  private Double longitude;
+  private Double latitude;
+  private Double averageScore;
+
+}

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/mapper/RestaurantMapper.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/mapper/RestaurantMapper.java
@@ -9,6 +9,7 @@ import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseGetRestauran
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseGetRestaurantSimpleDto;
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseLocationDto;
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseRatingDto;
+import com.wanted.lunchmapservice.restaurant.controller.dto.RestaurantResponseDto;
 import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -36,6 +37,38 @@ public class RestaurantMapper {
         .build();
   }
 
+  public ResponseDto<CustomPage<RestaurantResponseDto>> toResponseNearDto(
+      Page<Restaurant> entityPage) {
+    return ResponseDto.<CustomPage<RestaurantResponseDto>>builder()
+        .data(toNearCustomPageDto(entityPage))
+        .code(HttpStatus.OK.value())
+        .message(HttpStatus.OK.getReasonPhrase())
+        .build();
+  }
+
+  public RestaurantResponseDto toRestaurantResponseDto(Restaurant restaurant) {
+    return RestaurantResponseDto.builder()
+        .id(restaurant.getId())
+        .locationId(restaurant.getLocation().getId())
+        .name(restaurant.getName())
+        .lotNumberAddress(restaurant.getLotNumberAddress())
+        .roadNameAddress(restaurant.getRoadNameAddress())
+        .zipCode(restaurant.getZipCode())
+        .latitude(restaurant.getLatitude())
+        .longitude(restaurant.getLongitude())
+        .averageScore(restaurant.getAverageScore())
+        .build();
+  }
+
+  private CustomPage<RestaurantResponseDto> toNearCustomPageDto(
+      Page<Restaurant> entityPage) {
+    return new CustomPage<>(toGetNearListDto(entityPage.getContent()),
+        new PageInfo(entityPage.getPageable().getOffset(), entityPage.getSize(),
+            entityPage.getTotalElements(), entityPage.isFirst(),
+            entityPage.getNumberOfElements(), entityPage.isFirst(),
+            entityPage.getTotalPages()));
+  }
+
   private CustomPage<ResponseGetRestaurantSimpleDto> toCustomPageDto(Page<Restaurant> entityPage) {
     return new CustomPage<>(toGetListDto(entityPage.getContent()),
         new PageInfo(entityPage.getPageable().getOffset(), entityPage.getSize(),
@@ -47,6 +80,10 @@ public class RestaurantMapper {
 
   private List<ResponseGetRestaurantSimpleDto> toGetListDto(List<Restaurant> entityList) {
     return entityList.stream().map(this::toGetSimpleDto).toList();
+  }
+
+  private List<RestaurantResponseDto> toGetNearListDto(List<Restaurant> entityList) {
+    return entityList.stream().map(this::toRestaurantResponseDto).toList();
   }
 
   private ResponseGetRestaurantSimpleDto toGetSimpleDto(Restaurant entity) {

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/repository/RestaurantQueryRepository.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/repository/RestaurantQueryRepository.java
@@ -10,5 +10,6 @@ public interface RestaurantQueryRepository {
   Page<Restaurant> findPageByFilter(Pageable pageable, RequestRestaurantGetFilterDto condition);
 
   Page<Restaurant> findNearByRestaurant(NearRestaurantRequestDto dto, Pageable pageable);
+  Page<Restaurant> findNearByRestaurantV2(NearRestaurantRequestDto dto, Pageable pageable);
 
 }

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/repository/RestaurantQueryRepository.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/repository/RestaurantQueryRepository.java
@@ -2,9 +2,13 @@ package com.wanted.lunchmapservice.restaurant.repository;
 
 import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
 import com.wanted.lunchmapservice.restaurant.repository.dto.RequestRestaurantGetFilterDto;
+import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RestaurantQueryRepository {
   Page<Restaurant> findPageByFilter(Pageable pageable, RequestRestaurantGetFilterDto condition);
+
+  Page<Restaurant> findNearByRestaurant(NearRestaurantRequestDto dto, Pageable pageable);
+
 }

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantQueryRepositoryImpl.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantQueryRepositoryImpl.java
@@ -4,16 +4,21 @@ import static com.wanted.lunchmapservice.location.entity.QLocation.location;
 import static com.wanted.lunchmapservice.restaurant.entity.QRestaurant.restaurant;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
 import com.wanted.lunchmapservice.restaurant.repository.RestaurantQueryRepository;
 import com.wanted.lunchmapservice.restaurant.repository.dto.RequestRestaurantGetFilterDto;
+import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
@@ -21,6 +26,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository {
   private final JPAQueryFactory query;
+  private static final Integer EARTH_RADIUS = 6371;
 
   @Override
   public Page<Restaurant> findPageByFilter(Pageable pageable, RequestRestaurantGetFilterDto condition){
@@ -44,6 +50,38 @@ public class RestaurantQueryRepositoryImpl implements RestaurantQueryRepository 
         );
 
     return PageableExecutionUtils.getPage(content,pageable, count::fetchOne);
+  }
+
+  @Override
+  public Page<Restaurant> findNearByRestaurant(NearRestaurantRequestDto dto, Pageable pageable) {
+    Double userLat = Double.parseDouble(dto.getCurrentLatitude());
+    Double userLng = Double.parseDouble(dto.getCurrentLongitude());
+
+    List<Restaurant> nearByRestaurants = query
+        .select(restaurant)
+        .from(restaurant)
+        .where(acosExpression(userLat, userLng).loe(dto.getRange()))
+        .orderBy(getOrderByExpression(userLat, userLng, pageable.getSort()))
+        .fetch();
+
+    JPAQuery<Long> count = query.select(restaurant.count())
+        .from(restaurant)
+        .where(acosExpression(userLat, userLng).loe(dto.getRange()));
+
+    return PageableExecutionUtils.getPage(nearByRestaurants, pageable, count::fetchOne);
+  }
+
+
+  //추 후 정렬 조건이 늘어나면 추가 예정
+  private OrderSpecifier<?> getOrderByExpression(Double userLat, Double userLng, Sort sort) {
+    return sort.equals(Sort.unsorted()) ? acosExpression(userLat, userLng).asc() : restaurant.averageScore.desc();
+  }
+
+  private NumberTemplate<Double> acosExpression(Double userLat, Double userLng) {
+    return Expressions.numberTemplate(Double.class,
+        "{0} * acos(cos(radians({1})) * cos(radians({2})) * cos(radians({3}) - radians({4})) + "
+            + "sin(radians({1})) * sin(radians({2})))",
+        EARTH_RADIUS, userLat, restaurant.latitude, userLng, restaurant.longitude);
   }
 
   private BooleanExpression cityNameEq(String cityName) {

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/repository/util/GeoLocationUtil.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/repository/util/GeoLocationUtil.java
@@ -8,13 +8,10 @@ public class GeoLocationUtil {
   private static final Integer EARTH_RADIUS = 6371;
   private static final Double DEVIATION = 3.0;
   public static double getDiffLongitude(double lat, double range){
-    return ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180) * Math.cos(Math.toRadians(lat))))) * getRange(range);
+    return ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180) * Math.cos(Math.toRadians(lat))))) * range;
   }
   public static double getDiffLatitude(double range){
-    return ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180)))) * getRange(range);
+    return ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180)))) * range;
   }
 
-  private static double getRange(double range){
-    return (range / 2) + DEVIATION;
-  }
 }

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/repository/util/GeoLocationUtil.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/repository/util/GeoLocationUtil.java
@@ -1,0 +1,20 @@
+package com.wanted.lunchmapservice.restaurant.repository.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.NONE)
+public class GeoLocationUtil {
+  private static final Integer EARTH_RADIUS = 6371;
+  private static final Double DEVIATION = 3.0;
+  public static double getDiffLongitude(double lat, double range){
+    return ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180) * Math.cos(Math.toRadians(lat))))) * getRange(range);
+  }
+  public static double getDiffLatitude(double range){
+    return ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180)))) * getRange(range);
+  }
+
+  private static double getRange(double range){
+    return (range / 2) + DEVIATION;
+  }
+}

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/service/RestaurantGetService.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/service/RestaurantGetService.java
@@ -6,10 +6,12 @@ import com.wanted.lunchmapservice.common.dto.ResponseDto;
 import com.wanted.lunchmapservice.common.exception.CommonException;
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseGetRestaurantDetailDto;
 import com.wanted.lunchmapservice.restaurant.controller.dto.ResponseGetRestaurantSimpleDto;
+import com.wanted.lunchmapservice.restaurant.controller.dto.RestaurantResponseDto;
 import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
 import com.wanted.lunchmapservice.restaurant.mapper.RestaurantMapper;
 import com.wanted.lunchmapservice.restaurant.repository.RestaurantRepository;
 import com.wanted.lunchmapservice.restaurant.repository.dto.RequestRestaurantGetFilterDto;
+import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -34,6 +36,11 @@ public class RestaurantGetService {
   private Restaurant validRestaurant(Long restaurantId) {
     return repository.findByIdFetch(restaurantId)
         .orElseThrow(() -> new CommonException(HttpStatus.NOT_FOUND, "맛집 정보가 존재하지 않습니다."));
+  }
+
+  public ResponseDto<CustomPage<RestaurantResponseDto>> findNearbyRestaurant(
+      NearRestaurantRequestDto dto,Pageable pageable) {
+    return mapper.toResponseNearDto(repository.findNearByRestaurant(dto, pageable));
   }
 }
 

--- a/src/main/java/com/wanted/lunchmapservice/restaurant/service/RestaurantGetService.java
+++ b/src/main/java/com/wanted/lunchmapservice/restaurant/service/RestaurantGetService.java
@@ -40,7 +40,7 @@ public class RestaurantGetService {
 
   public ResponseDto<CustomPage<RestaurantResponseDto>> findNearbyRestaurant(
       NearRestaurantRequestDto dto,Pageable pageable) {
-    return mapper.toResponseNearDto(repository.findNearByRestaurant(dto, pageable));
+    return mapper.toResponseNearDto(repository.findNearByRestaurantV2(dto, pageable));
   }
 }
 

--- a/src/test/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantRepositoryTest.java
+++ b/src/test/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantRepositoryTest.java
@@ -4,6 +4,7 @@ import com.wanted.lunchmapservice.common.config.QueryDslConfig;
 import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
 import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
 import com.wanted.lunchmapservice.restaurant.repository.RestaurantRepository;
+import com.wanted.lunchmapservice.restaurant.repository.util.GeoLocationUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +53,20 @@ class RestaurantRepositoryTest {
     Assertions.assertThat(resultByHaversine.getTotalElements()).isLessThanOrEqualTo(resultByEnhanced.getTotalElements());
   }
 
+  @Test
+  @DisplayName("인근지역 조회 레포지토리 테스트 : Haversine 공식 활용 시 상하 죄우의 좌표 값보다 작거나 같은 데이터를 가져야한다")
+  void findNearByRestaurantHaversineTest() {
+    // given
+    Page<Restaurant> resultList = repository.findNearByRestaurant(dto, pageable);
 
+    double diffLatitude = GeoLocationUtil.getDiffLatitude(range);
+    double diffLongitude = GeoLocationUtil.getDiffLongitude(lat,range);
+
+    for (Restaurant result : resultList) {
+      Assertions.assertThat(result.getLatitude()).isLessThanOrEqualTo(lat + diffLatitude).isGreaterThanOrEqualTo(lat - diffLatitude);
+      Assertions.assertThat(result.getLongitude()).isLessThanOrEqualTo(lon + diffLongitude).isGreaterThanOrEqualTo(lon - diffLongitude);
+    }
+
+  }
 
 }

--- a/src/test/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantRepositoryTest.java
+++ b/src/test/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantRepositoryTest.java
@@ -1,15 +1,10 @@
 package com.wanted.lunchmapservice.restaurant.repository.implement;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.wanted.lunchmapservice.common.config.QueryDslConfig;
 import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
 import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
 import com.wanted.lunchmapservice.restaurant.repository.RestaurantRepository;
-import lombok.Getter;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +16,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.util.StopWatch;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -30,7 +24,7 @@ class RestaurantRepositoryTest {
 
   final Double lat = 37.2738734428;
   final Double lon = 126.9412806228;
-  final Double range = 10.0;
+  final Double range = 4.0;
   @Autowired
   RestaurantRepository repository;
   NearRestaurantRequestDto dto;
@@ -49,53 +43,15 @@ class RestaurantRepositoryTest {
 
   //
   @Test
-  @DisplayName("인근지역 조회 레포지토리 테스트")
+  @DisplayName("성능 개선 전 코드와 현재 코드 중 현재 코드가 더 많거나 같은 양의 데이터를 가져야한다.")
   void findNearByRestaurantTest() {
     // given
-    StopWatch stopWatch = new StopWatch();
-    stopWatch.start();
-    Page<Restaurant> nearByRestaurant = repository.findNearByRestaurant(dto, pageable);
-    stopWatch.stop();
+    Page<Restaurant> resultByHaversine = repository.findNearByRestaurant(dto, pageable);
+    Page<Restaurant> resultByEnhanced = repository.findNearByRestaurantV2(dto, pageable);
 
-    GeoLocation location = new GeoLocation(lat, lon, range);
-
-    for (Restaurant result : nearByRestaurant) {
-      Assertions.assertThat(result.getLongitude()).isGreaterThan(location.getMinLon())
-          .isLessThan(location.getMaxLon());
-      Assertions.assertThat(result.getLatitude()).isGreaterThan(location.getMinLat())
-          .isLessThan(location.getMaxLat());
-
-    }
+    Assertions.assertThat(resultByHaversine.getTotalElements()).isLessThanOrEqualTo(resultByEnhanced.getTotalElements());
   }
 
-  @Getter
-  class GeoLocation {
 
-    private static final Integer EARTH_RADIUS = 6371;
-    double minLat;
-    double maxLat;
-    double minLon;
-    double maxLon;
 
-    double diffLat;
-    double diffLon;
-
-    public GeoLocation(double lat, double lon, double range) {
-      initData(lat, lon, range);
-      this.minLat = lat - diffLat;
-      this.maxLat = lat + diffLat;
-      this.minLon = lon - diffLon;
-      this.maxLon = lon + diffLon;
-    }
-
-    //각 계산 방식의 오차 산정
-    private void initData(double lat, double lon, double range) {
-      range = (range / 2) + 5;
-      //1M 이동 했을 때 걸리는 위도
-      diffLat = ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180)))) * range;
-      //m당 x 좌표 이동 값
-      diffLon =
-          ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180) * Math.cos(Math.toRadians(lat))))) * range;
-    }
-  }
 }

--- a/src/test/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantRepositoryTest.java
+++ b/src/test/java/com/wanted/lunchmapservice/restaurant/repository/implement/RestaurantRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.wanted.lunchmapservice.restaurant.repository.implement;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.wanted.lunchmapservice.common.config.QueryDslConfig;
+import com.wanted.lunchmapservice.restaurant.controller.dto.NearRestaurantRequestDto;
+import com.wanted.lunchmapservice.restaurant.entity.Restaurant;
+import com.wanted.lunchmapservice.restaurant.repository.RestaurantRepository;
+import lombok.Getter;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.StopWatch;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({QueryDslConfig.class})
+class RestaurantRepositoryTest {
+
+  final Double lat = 37.2738734428;
+  final Double lon = 126.9412806228;
+  final Double range = 10.0;
+  @Autowired
+  RestaurantRepository repository;
+  NearRestaurantRequestDto dto;
+  Pageable pageable;
+
+  @BeforeEach
+  void init() {
+
+    dto = NearRestaurantRequestDto.builder()
+        .currentLatitude(String.valueOf(lat))
+        .currentLongitude(String.valueOf(lon))
+        .range(range)
+        .build();
+    pageable = PageRequest.of(0, 100);
+  }
+
+  //
+  @Test
+  @DisplayName("인근지역 조회 레포지토리 테스트")
+  void findNearByRestaurantTest() {
+    // given
+    StopWatch stopWatch = new StopWatch();
+    stopWatch.start();
+    Page<Restaurant> nearByRestaurant = repository.findNearByRestaurant(dto, pageable);
+    stopWatch.stop();
+
+    GeoLocation location = new GeoLocation(lat, lon, range);
+
+    for (Restaurant result : nearByRestaurant) {
+      Assertions.assertThat(result.getLongitude()).isGreaterThan(location.getMinLon())
+          .isLessThan(location.getMaxLon());
+      Assertions.assertThat(result.getLatitude()).isGreaterThan(location.getMinLat())
+          .isLessThan(location.getMaxLat());
+
+    }
+  }
+
+  @Getter
+  class GeoLocation {
+
+    private static final Integer EARTH_RADIUS = 6371;
+    double minLat;
+    double maxLat;
+    double minLon;
+    double maxLon;
+
+    double diffLat;
+    double diffLon;
+
+    public GeoLocation(double lat, double lon, double range) {
+      initData(lat, lon, range);
+      this.minLat = lat - diffLat;
+      this.maxLat = lat + diffLat;
+      this.minLon = lon - diffLon;
+      this.maxLon = lon + diffLon;
+    }
+
+    //각 계산 방식의 오차 산정
+    private void initData(double lat, double lon, double range) {
+      range = (range / 2) + 5;
+      //1M 이동 했을 때 걸리는 위도
+      diffLat = ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180)))) * range;
+      //m당 x 좌표 이동 값
+      diffLon =
+          ((1 / (EARTH_RADIUS * 1 * (Math.PI / 180) * Math.cos(Math.toRadians(lat))))) * range;
+    }
+  }
+}


### PR DESCRIPTION
## What is this PR

- 인근 지연 레스토랑 조회 API 구현
- 쿼리 튜닝을 통한 성능 개선 0.3 -> 0.1 초 성능 개선

### haversine 활용
```java
  private NumberTemplate<Double> acosExpression(Double userLat, Double userLng) {
    return Expressions.numberTemplate(Double.class,
        "{0} * acos(cos(radians({1})) * cos(radians({2})) * cos(radians({3}) - radians({4})) + "
            + "sin(radians({1})) * sin(radians({2})))",
        EARTH_RADIUS, userLat, restaurant.latitude, userLng, restaurant.longitude);
  }
```
- DB 단에서 주어진 좌표 대비 상대 거리를 연산하기 때문에 성능 저하가 발생
    - 저장된 모든 데이터에서 주어진 좌표 대비 거리를 연산한 뒤 조회를 진행해야되기 때문

### 양 끝 위도 경도를 활용
```java
        .where(
            restaurant.latitude.between(userLat - getDiffLatitude(dto.getRange()), userLat + getDiffLatitude(dto.getRange()))
                .and(
                restaurant.longitude.between(userLng - getDiffLongitude(userLat, dto.getRange()), userLng + getDiffLongitude(userLat, dto.getRange()))
            )
```
- 양 끝의 위도 경도만을 구한 뒤 조회
- 모든 데이터의 연산을 진행하지 않기 때문에 성능상 이점 발생

## Issue Number

fix #6